### PR TITLE
export types in rollup configuration

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,6 +30,11 @@ export default {
       useTsconfigDeclarationDir: true,
       tsconfigOverride: {
         exclude: ['**/*.test.ts', '**/*.test.tsx'],
+        compilerOptions: {
+          declaration: true,
+          declarationDir: './dist',
+          emitDeclarationOnly: false,
+        },
       },
     }),
   ],


### PR DESCRIPTION
Hi,
i've noticed this package does not emit types, even if they are declared in package.json.

This should fix!